### PR TITLE
Added Lemonbar-xft-git

### DIFF
--- a/packages/lemonbar-xft-git/README.md
+++ b/packages/lemonbar-xft-git/README.md
@@ -1,0 +1,4 @@
+# Lemonbar-xft
+
+Fork of Lemonbar with xft support for .ttf fonts etc.
+Uses the same source as the AUR version of this package

--- a/packages/lemonbar-xft-git/README.md
+++ b/packages/lemonbar-xft-git/README.md
@@ -1,4 +1,5 @@
 # Lemonbar-xft
 
 Fork of Lemonbar with xft support for .ttf fonts etc.
-Uses the same source as the AUR version of this package
+Uses the same source as the AUR version of this package.
+Version is unspecified.

--- a/packages/lemonbar-xft-git/lemonbar-xft-git.pacscript
+++ b/packages/lemonbar-xft-git/lemonbar-xft-git.pacscript
@@ -1,0 +1,18 @@
+name="lemonbar-xft-git"
+version="0.0.1"
+url="https://gitlab.com/protesilaos/lemonbar-xft/-/archive/xft-port/lemonbar-xft-xft-port.zip"
+build_depends="build-essential libx11-dev libxft-dev libx11-xcb-dev libxcb-randr0-dev libxcb-xinerama0-dev"
+depends=""
+breaks="bar lemonbar"
+description=“A lightweight xcb based bar with ported xft support.”
+hash=“c2ca60846e0cade326969dd3f1f10e723f1a94d90d0335132b844932e41effff”
+prepare() {
+}
+
+build() {
+        make -j$(nproc)
+}
+
+install() {
+          sudo make install DESTDIR=/usr/src/pacstall
+}


### PR DESCRIPTION
Popular package on the AUR and alternative to polybar, i3bar and dwmbar. Available from ubuntu repos but without xft-font support.
No idea how to test a pacscript file locally. No idea what the official version number is for this as it is not mentioned on the Gitlab page for this build.