### PR TITLE
Fixed an error with the quotes . Added dmenu

### DIFF
--- a/packages/dmenu/README.md
+++ b/packages/dmenu/README.md
@@ -1,0 +1,2 @@
+# Dmenu
+A generic menu for X. This version is from the original source on https://tools.suckless.org/dmenu . 

--- a/packages/dmenu/dmenu.pacscript
+++ b/packages/dmenu/dmenu.pacscript
@@ -1,0 +1,18 @@
+name="dmenu"
+version="5.0"
+url="https://dl.suckless.org/tools/dmenu-5.0.tar.gz"
+build_depends="libxinerama libxft"
+depends="sh"
+breaks="dmenu dmenu_run dmenu_path"
+description="A generic menu for X"
+hash="fe18e142c4dbcf71ba5757dbbdea93b1c67d58fc206fc116664f4336deef6ed3"
+prepare() {
+}
+
+build() {
+        make -j$(nproc)
+}
+
+install() {
+          sudo make install DESTDIR=/usr/src/pacstall
+}

--- a/packages/lemonbar-xft-git/lemonbar-xft-git.pacscript
+++ b/packages/lemonbar-xft-git/lemonbar-xft-git.pacscript
@@ -4,8 +4,8 @@ url="https://gitlab.com/protesilaos/lemonbar-xft/-/archive/xft-port/lemonbar-xft
 build_depends="build-essential libx11-dev libxft-dev libx11-xcb-dev libxcb-randr0-dev libxcb-xinerama0-dev"
 depends=""
 breaks="bar lemonbar"
-description=“A lightweight xcb based bar with ported xft support.”
-hash=“c2ca60846e0cade326969dd3f1f10e723f1a94d90d0335132b844932e41effff”
+description="A lightweight xcb based bar with ported xft support."
+hash="c2ca60846e0cade326969dd3f1f10e723f1a94d90d0335132b844932e41effff"
 prepare() {
 }
 


### PR DESCRIPTION
This error was found on testing when the file was committed to the official repo. (unicode quotes instead of normal ASCII) prevented the hash form being parsed correctly
Added dmenu sourced from suckless.org.