### PR TITLE
Add soundux

### DIFF
--- a/packages/soundux/soundux.pacscript
+++ b/packages/soundux/soundux.pacscript
@@ -12,7 +12,7 @@ build() {
   mkdir -p build
   cd build
   cmake ..
-  cmake --build . --config Release
+  cmake --build . --config Release -j$(nproc)
 }
 
 install() {

--- a/packages/soundux/soundux.pacscript
+++ b/packages/soundux/soundux.pacscript
@@ -1,0 +1,20 @@
+name="soundux"
+pkgname="soundux"
+version="0.2.2b3"
+url="https://github.com/Soundux/Soundux/releases/download/0.2.2_b3/soundux-0.2.2_b3.tar.gz"
+build_depends="build-essential cmake libx11-dev libxi-dev libwebkit2gtk-4.0-dev libappindicator3-dev libssl-dev libpulse-dev"
+depends="libgtk-3-0 libwnck-3-0 libappindicator3-1 libwebkit2gtk-4.0-37 libx11-6 pulseaudio pulseaudio-utils"
+description="A cross-platform soundboard"
+hash="76c08786da00ad951a96c6f547a952bd0aa1fbaeac2a5f991bc6873355735777"
+maintainer="Soundux developers <info@soundux.rocks>"
+
+build() {
+  mkdir -p build
+  cd build
+  cmake ..
+  cmake --build . --config Release
+}
+
+install() {
+  sudo make install DESTDIR=/usr/src/pacstall/soundux
+}


### PR DESCRIPTION
This PR adds a pacscript for Soundux
I have tested it in a Ubuntu 21.04 VM and it worked fine

One small issue I've noticed: When removing the package the symlink in `/opt` doesn't get removed. I think that's an issue with pacstall itself, isn't it?
![image](https://user-images.githubusercontent.com/24937357/117827346-2c58d580-b271-11eb-94cb-8da15755c44a.png)
